### PR TITLE
Remove dependency on `unstable/list/lib`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*~
+compiled/

--- a/info.rkt
+++ b/info.rkt
@@ -5,5 +5,5 @@
 
 (define deps '("at-exp-lib"
                "base" "scheme-lib" "compatibility-lib" "gui-lib" "images-lib"
-               "pict-lib" "unstable-lib" "draw-lib"))
+               "pict-lib" "draw-lib"))
 (define build-deps '("racket-doc" "scribble-lib" "redex-pict-lib"))

--- a/trace-browser/graph-pasteboard.rkt
+++ b/trace-browser/graph-pasteboard.rkt
@@ -3,7 +3,7 @@
 (require mrlib/graph
          racket/gui/base
          (only-in racket/string string-normalize-spaces)
-         (only-in unstable/gui/pict dark light)
+         (only-in pict/color dark light)
          "quadtree.rkt")
 
 (provide graph-pasteboard%)


### PR DESCRIPTION
As of pict 1.4, the `pict/color` collection will include `light` and `dark`, which will make this dependency unnecessary.

This PR is not compatible with Racket 6.2.1, as it does not include that change. You can fix this by adding a version exception on pkgs.racket-lang.org.

This code will keep working with future versions of Racket, even without this PR, so long as the dependency to `unstable-lib` is preserved.
